### PR TITLE
New template and todonotes bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 *.cb
 *.cb2
 .*.lb
+dfg.pdf
+dfg-german.pdf
 
 ## Intermediate documents:
 *.dvi

--- a/Header.tex
+++ b/Header.tex
@@ -44,10 +44,5 @@
 \DeclareBibliographyCategory{patents_pending}
 \DeclareBibliographyCategory{patents}
 %
-\addtocategory{reviewed}{Hoelzer:16} 
-\nocite{}
-\addtocategory{nonreviewed}{Desiro:18} 
-\addtocategory{patents_pending}{} 
-\addtocategory{patents}{} 
 
 \input{highlight_box.tex}

--- a/Header.tex
+++ b/Header.tex
@@ -22,21 +22,6 @@
 %\newcommand{\todo}[1]{\xspace{\textcolor{red}{\bfseries[TODO: #1]}}\xspace}
 \newcommand{\cp}[1]{\xspace{\textcolor{blue}{\bfseries[COPIED: #1]}}\xspace}
 
-% todonotes and a switch for final
-
-\usepackage{ifthen}
-\newboolean{finalcompile}
-
-
-\ifthenelse{\boolean{finalcompile}}{
-\usepackage[disable]{todonotes}
-\usepackage[final]{showlabels}
-}{
-\usepackage{todonotes}
-\newcommand{\todonote}[2][]{\tikzexternaldisable\todo[#1]{#2}\tikzexternalenable} %needed for externalization
-\usepackage{showlabels}
-}
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Declare your Bibliography
 \DeclareBibliographyCategory{reviewed}

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ conda create -n biber -c malramsay biber
 conda activate biber
 ```
 
+## ToDo-Notes and reference labels
+By default the todonotes package is enabled. You can see it working by looking at the \todo[inline]{foo} statements in the text. It is self-explaining.
+
+In addition you will se some labels at the margins. These are caused by another plugin which will just print the name of the label stated in `\label{}`. This can help by referencing sections and stuff.
+
+To turn both of them off (e.g. for the final version) jsut change `\setboolean{finalcompile}{false}` in dfg.tex to `\setboolean{finalcompile}{true}`.
+
 ## Customization
 
 Most of customization (citation style, etc.) can be done by changes in the `proposal.sty`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LaTeX DFG template 
 
-__Last updated: August 2020__
+__Last updated: February 2021__
 
 A LaTeX template for a basic DFG (Deutsche Forschungsgemeinschaft, German Research Foundation) grant proposal. __Attention__: you need ``pdflatex`` and ``biber`` (not ``bibtex``) to compile the document. 
 
@@ -8,7 +8,7 @@ A LaTeX template for a basic DFG (Deutsche Forschungsgemeinschaft, German Resear
 
 This template is based on the template of the [Measurement Engineering
 Group](https://github.com/emtpb/proposal_dfg) and based on the RTF
-[DFG form 53_01_en 04/20](http://www.dfg.de/formulare/53_01_elan/53_01_en_elan.rtf), __last accessed in August 2020__.
+[DFG form 53_01_en 11/20](http://www.dfg.de/formulare/53_01_elan/53_01_en_elan.rtf), __last accessed in February 2021__.
 
 Thanks to [@nneuss](https://github.com/nneuss) a German version is also available. Please use `dfg-german.tex` instead of `dfg.tex` for the German version. 
 

--- a/dfg-german.tex
+++ b/dfg-german.tex
@@ -25,6 +25,14 @@
 \newcommand{\applicants}{Dr.\ Martin H\"olzer, Robert Koch Institute, Berlin}
 \newcommand{\project}{Project title}
 
+% declare bibliography categroies
+
+\addtocategory{reviewed}{Hoelzer:16} 
+\nocite{}
+\addtocategory{nonreviewed}{Desiro:18} 
+\addtocategory{patents_pending}{} 
+\addtocategory{patents}{} 
+% 
 \begin{document}
 \pagestyle{empty}
 \setcounter{page}{0}

--- a/dfg-german.tex
+++ b/dfg-german.tex
@@ -118,7 +118,7 @@ None.
 
 \subsection{Arbeitsprogramm inkl. vorgesehener Untersuchungsmethoden}
 %For each applicant
-\todo{ca.\ 6-8 pages; ca. 4-8 WPs}
+\todo[inline]{ca.\ 6-8 pages; ca. 4-8 WPs}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
 %%%%% BEGIN OF WORK PACKAGES %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -156,7 +156,7 @@ Für jede Antragstellerin und jeden Antragsteller
 %% This is not directly part of the DFG TRF template, but always helpful in my eyes
 \let\theparagraph=\oldpara
 \paragraph*{Zeitplan}
-\todo{put timeline here, if needed}
+\todo[inline]{put timeline here, if needed}
 
 
 \section{Literaturverzeichnis zum Stand der Forschung, zu den Zielen und dem Arbeitsprogramm}
@@ -165,7 +165,7 @@ Für jede Antragstellerin und jeden Antragsteller
 \printbibliography[notcategory=reviewed, notcategory=nonreviewed, notcategory=patents_pending, notcategory=patents, heading=none]
 
 \section{Relevanz von Geschlecht und/oder Vielfältigkeit}
-\todo{Text}
+\todo[inline]{Text}
 
 
 \clearpage
@@ -178,22 +178,22 @@ Für jede Antragstellerin und jeden Antragsteller
 \subsection{Angaben zu ethischen und/oder rechtlichen Aspekten des Vorhabens}
 
 \subsubsection{Allgemeine ethische Aspekte}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsubsection{Erläuterungen zu den vorgesehenen Untersuchungen bei Versuchen an 
 Menschen oder an vom Menschen entnommenem Material}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsubsection{Erläuterungen zu den vorgesehenen Untersuchungen bei Versuchen an Tieren}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsubsection{Erläuterungen zu Forschungsvorhaben an genetischen Ressourcen (oder 
 darauf bezogenem traditionellem Wissen) aus dem Ausland}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsubsection{Erläuterungen zu möglichen sicherheitsrelevanten Aspekten („Dual-Use 
 Research of Concern``, Außenwirtschaftsrecht)}
-\todo{Text}
+\todo[inline]{Text}
 
 
 \subsection{Umgang mit den im Projekt erzielten Forschungsdaten}
@@ -206,7 +206,7 @@ allow complete reproducibility of all analyses, the source code and executed
 comands will be also made publicly available
 (\href{https://github.com/}{GitHub}).  Thus, all relevant data will become
 accessible for future use. 
-\todo{FAIR principals}
+\todo[inline]{FAIR principals}
 
 \subsection{Weitere Angaben}
 %Please use this section for any additional information you feel is relevant which has not been provided elsewhere.
@@ -222,7 +222,7 @@ In submitting a proposal to the DFG, I agree to adhere to the DFG's rules of goo
 \subsection{Angaben zur Dienststellung}
 %for each applicant, state the last name, first name, and employment status
 %(including duration of contract and funding body, if on a fixed-term contract)
-H\"olzer, Martin -- postdoctoral researcher, \todo{additional information}
+H\"olzer, Martin -- postdoctoral researcher, \todo[inline]{additional information}
 
 \subsection{Angaben zur Erstantragstellung}
 %only if applicable: Last name, first name of first-time applicant
@@ -241,10 +241,10 @@ the project funds:
 \end{itemize}
 
 \subsection{Zusammenarbeit mit Wissenschaftlerinnen und Wissenschaftlern in Deutschland in diesem Projekt}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Zusammenarbeit mit Wissenschaftlerinnen und Wissenschaftlern im Ausland in diesem Projekt}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Wissenschaftlerinnen und Wissenschaftler, mit denen in den letzten 
 drei Jahren wissenschaftlich zusammengearbeitet wurde}
@@ -263,7 +263,7 @@ None.
 
 \subsection{Apparative Ausstattung}
 %List larger instruments that will be available to you for the project. These may include large computer facilities if computing capacity will be needed.
-\todo{Text}
+\todo[inline]{Text}
 Man kann etwas in Abbildung~\ref{fig:some_nice_graph} sehen\todo[inline]{the figure has to be made}.
 \begin{figure}
 \centering
@@ -274,7 +274,7 @@ Man kann etwas in Abbildung~\ref{fig:some_nice_graph} sehen\todo[inline]{the fig
 
 \subsection{Weitere Antragstellungen}
 %List any funding proposals for this project and/or major instrumentation previously submitted to a third party.
-\todo{Text}
+\todo[inline]{Text}
 
 %\section{Requested modules/funds}
 %Explain each item for each applicant (stating last name, first name)
@@ -289,7 +289,7 @@ Man kann etwas in Abbildung~\ref{fig:some_nice_graph} sehen\todo[inline]{the fig
 
 \subsubsection{Personalmittel}
 \begin{funds}[funding for staff]
-The following staff positions are requested for \todo{xx} years each:
+The following staff positions are requested for \todo[inline]{xx} years each:
 
 \positionmul{Research associate, TV-L 13, 36 months}{5375}{36}
 \positionmul{Hiwi, TV-L 13, 12 months}{450}{12}
@@ -339,26 +339,28 @@ Our laboratory is well equipped; all necessary instruments are available.
 %% otherwise, just delete/comment
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\vspace*{2cm}\todo{The following are additional/other modules one might want to apply for. Otherwise, just delete/comment}
+\vspace*{2cm}\todo[inline]{The following are additional/other modules one might want to apply for. Otherwise, just delete/comment}
 
 \subsection{Modul Eigene Stelle}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Modul Vertretung}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Modul Rotationsstellen}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Modul Mercator Fellow}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Modul Projektspezifische Workshops}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Modul Öffentlichkeitsarbeit}
-\todo{Text}
+\todo[inline]{Text}
 
+\subsection{Modul Pauschale für Chancengleichheitsmaßnahmen}
+\todo[inline]{Bitte erläutern Sie ausführlich die geplanten Maßnahmen zur Förderung der Vielfalt und Chancengleichheit. Sofern Sie Ihren Sachbeihilfeantrag innerhalb eines Verbundkontextes stellen, so kann diese Pauschale nur gebündelt im Koordinierungsprojekt beantragt werden.}
 
 \section{Unterschrift}
 

--- a/dfg-german.tex
+++ b/dfg-german.tex
@@ -9,12 +9,14 @@
 \usepackage[utf8]{inputenc}
 \usepackage[german]{proposal}
 
-% all config is done in Header.tex
-\input{Header.tex}
 
 % final version?
 
 \setboolean{finalcompile}{false}
+
+% all config is done in Header.tex
+\input{Header.tex}
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%  TITELSEITE  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/dfg.tex
+++ b/dfg.tex
@@ -265,8 +265,8 @@ None.
 As something can be seen in figure~\ref{fig:some_nice_graph} \todo[inline]{the figure has to be made}.
 \begin{figure}
 \centering
-\missingfigure{Schematic of a souverein-class warp-reactor}
-\caption{some nice graph}
+\missingfigure{schematics of a souvereign-class warp-reactor}
+\caption{warp reactor}
 \label{fig:some_nice_graph}
 \end{figure}
 

--- a/dfg.tex
+++ b/dfg.tex
@@ -23,6 +23,14 @@
 \newcommand{\applicants}{Dr.\ Martin H\"olzer, Robert Koch Institute, Berlin}
 \newcommand{\project}{Project title}
 
+% declare bibliography categroies
+
+\addtocategory{reviewed}{Hoelzer:16} 
+\nocite{}
+\addtocategory{nonreviewed}{Desiro:18} 
+\addtocategory{patents_pending}{} 
+\addtocategory{patents}{} 
+
 \begin{document}
 \pagestyle{empty}
 \setcounter{page}{0}
@@ -103,7 +111,7 @@ None.
 \section{Objectives and work programme}
 
 \subsection{Anticipated total duration of the project}
-Financial support is requested for \todo{three years}.
+Financial support is requested for \todo[inline]{three years}.
 
 \subsection{Objectives}
 \let\oldpara=\theparagraph
@@ -114,7 +122,7 @@ Financial support is requested for \todo{three years}.
 
 \subsection{Work programme including proposed research methods}
 %For each applicant
-\todo{ca.\ 6-8 pages; ca. 4-8 WPs}
+\todo[inline]{ca.\ 6-8 pages; ca. 4-8 WPs}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
 %%%%% BEGIN OF WORK PACKAGES %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -150,7 +158,7 @@ Financial support is requested for \todo{three years}.
 %% This is not directly part of the DFG TRF template, but always helpful in my eyes
 \let\theparagraph=\oldpara
 \paragraph*{Time considerations}
-\todo{put timeline here, if needed}
+\todo[inline]{put timeline here, if needed}
 
 
 \section{Bibliography concerning the state of the art, the research objectives, and the work programme}
@@ -159,7 +167,7 @@ Financial support is requested for \todo{three years}.
 \printbibliography[notcategory=reviewed, notcategory=nonreviewed, notcategory=patents_pending, notcategory=patents, heading=none]
 
 \section{Relevance of sex, gender and/or diversity}
-\todo{Text}
+\todo[inline]{Text}
 
 
 \clearpage
@@ -172,19 +180,19 @@ Financial support is requested for \todo{three years}.
 \subsection{Ethical and/or legal aspects of the project}
 
 \subsubsection{General ethical aspects}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsubsection{Descriptions of proposed investigations involving experiments on humans or human materials}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsubsection{Descriptions of proposed investigations involving experiments on animals}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsubsection{Descriptions of projects involving genetic resources (or associated traditional knowledge) from a foreign country}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsubsection{Descriptions of investigations involving dual use research of concern, foreign trade regulations}
-\todo{Text}
+\todo[inline]{Text}
 
 
 \subsection{Data handling}
@@ -197,7 +205,7 @@ allow complete reproducibility of all analyses, the source code and executed
 comands will be also made publicly available
 (\href{https://github.com/}{GitHub}).  Thus, all relevant data will become
 accessible for future use. 
-\todo{FAIR principals}
+\todo[inline]{FAIR principals}
 
 \subsection{Other information}
 %Please use this section for any additional information you feel is relevant which has not been provided elsewhere.
@@ -213,7 +221,7 @@ In submitting a proposal to the DFG, I agree to adhere to the DFG's rules of goo
 \subsection{Employment status information}
 %for each applicant, state the last name, first name, and employment status
 %(including duration of contract and funding body, if on a fixed-term contract)
-H\"olzer, Martin -- postdoctoral researcher, \todo{additional information}
+H\"olzer, Martin -- postdoctoral researcher, \todo[inline]{additional information}
 
 \subsection{First-time proposal data}
 %only if applicable: Last name, first name of first-time applicant
@@ -232,10 +240,10 @@ the project funds:
 \end{itemize}
 
 \subsection{Researchers in Germany with whom you have agreed to cooperate on this project}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Researchers abroad with whom you have agreed to cooperate on this project}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Researchers with whom you have collaborated scientifically within the past three years}
 % This information will help avoid potential conflicts of interest.
@@ -253,18 +261,18 @@ None.
 
 \subsection{Scientific equipment}
 %List larger instruments that will be available to you for the project. These may include large computer facilities if computing capacity will be needed.
-\todo{Text}
+\todo[inline]{Text}
 As something can be seen in figure~\ref{fig:some_nice_graph} \todo[inline]{the figure has to be made}.
 \begin{figure}
 \centering
-\missingfigure{some nice graph}
+\missingfigure{Schematic of a souverein-class warp-reactor}
 \caption{some nice graph}
 \label{fig:some_nice_graph}
 \end{figure}
 
 \subsection{Other submissions}
 %List any funding proposals for this project and/or major instrumentation previously submitted to a third party.
-\todo{Text}
+\todo[inline]{Text}
 
 %\section{Requested modules/funds}
 %Explain each item for each applicant (stating last name, first name)
@@ -279,7 +287,7 @@ As something can be seen in figure~\ref{fig:some_nice_graph} \todo[inline]{the f
 
 \subsubsection{Funding for Staff}
 \begin{funds}[funding for staff]
-The following staff positions are requested for \todo{xx} years each:
+The following staff positions are requested for \todo[inline]{xx} years each:
 
 \positionmul{Research associate, TV-L 13, 36 months}{5375}{36}
 \positionmul{Hiwi, TV-L 13, 12 months}{450}{12}
@@ -329,25 +337,28 @@ Our laboratory is well equipped; all necessary instruments are available.
 %% otherwise, just delete/comment
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\vspace*{2cm}\todo{The following are additional/other modules one might want to apply for. Otherwise, just delete/comment}
+\vspace*{2cm}\todo[inline]{The following are additional/other modules one might want to apply for. Otherwise, just delete/comment}
 
 \subsection{Module Temporary Position for Principal Investigator}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Module Replacement Funding}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Module Temporary Clinician Substitute}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Module Mercator Fellows}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Module Workshop Funding}
-\todo{Text}
+\todo[inline]{Text}
 
 \subsection{Module Public Relations Funding}
-\todo{Text}
+\todo[inline]{Text}
+
+\subsection{Module Standard Allowance for Gender Equality Measures}
+\todo[inline]{Text}
 
 
 \section{Signature}

--- a/dfg.tex
+++ b/dfg.tex
@@ -9,12 +9,14 @@
 \usepackage[utf8]{inputenc}
 \usepackage[english]{proposal}
 
-% all config is done in Header.tex
-\input{Header.tex}
-
 % final version?
 
 \setboolean{finalcompile}{false}
+
+% all config is done in Header.tex
+\input{Header.tex}
+
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%  TITELSEITE  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -354,7 +356,7 @@ Our laboratory is well equipped; all necessary instruments are available.
 \subsection{Module Workshop Funding}
 \todo[inline]{Text}
 
-\subsection{Module Public Relations Funding}
+\subsection{Module Public Relations}
 \todo[inline]{Text}
 
 \subsection{Module Standard Allowance for Gender Equality Measures}

--- a/dfg.tex
+++ b/dfg.tex
@@ -358,7 +358,7 @@ Our laboratory is well equipped; all necessary instruments are available.
 \todo[inline]{Text}
 
 \subsection{Module Standard Allowance for Gender Equality Measures}
-\todo[inline]{Text}
+\todo[inline]{Please detail what measures are planned to promote diversity and equal opportunities.  If you are submitting your proposal for an individual research grant within a network, note that this standard allowance may only be applied for within the coordination project. The coordination project must combine all such requests in its calculation.}
 
 
 \section{Signature}

--- a/proposal.sty
+++ b/proposal.sty
@@ -59,8 +59,8 @@
 }
 \ExecuteOptions{german}
 \ProcessOptions\relax
-\ohead{\pagemark}
-\cfoot{}
+\ohead*{\pagemark}
+\cfoot*{}
 \chead{}
 
 \KOMAoptions{paper=a4}
@@ -90,3 +90,18 @@
 \newcommand{\position}[2]{\par #1 \hfill \num[round-mode = places, round-precision = 2]{#2}\,\euro \FPeval{\funds}{\funds + #2}}
 % Same as above but with multiples of a position.
 \newcommand{\positionmul}[3]{\par #1 \hfill \num{#3} $\times$ \num[round-mode = places, round-precision = 2]{#2}\,\euro \FPeval{\funds}{\funds + #3*#2}}
+
+% todonotes and a switch for final
+
+\usepackage{ifthen}
+\newboolean{finalcompile}
+
+
+\ifthenelse{\boolean{finalcompile}}{
+\usepackage[disable]{todonotes}
+\usepackage[final]{showlabels}
+}{
+\usepackage{todonotes}
+\newcommand{\todonote}[2][]{\tikzexternaldisable\todo[#1]{#2}\tikzexternalenable} %needed for externalization
+\usepackage{showlabels}
+}


### PR DESCRIPTION
It should now be up to date. "\section{Relevance of sex, gender and/or diversity}" as discussed in #15 is still there. I think this closes #15 and #16 .