### PR TITLE
added gantt chart, fixed wrong workpackage heading numbers

### DIFF
--- a/dfg.tex
+++ b/dfg.tex
@@ -131,18 +131,21 @@ Financial support is requested for \todo[inline]{three years}.
 \addtocounter{secnumdepth}{1}
 %\newcommand\WP{WP\arabic{paragraph}}
 \renewcommand{\theparagraph}{WP\arabic{paragraph}}
+\RedeclareSectionCommand[beforeskip=-2.5ex plus-1ex minus -.2ex,%
+afterskip=2.5ex plus 0.2ex minus 0.2ex]{paragraph}
+%numbered sub-workpackages are supported - just use \subparagraph{}
+\RedeclareSectionCommand[indent=0pt, beforeskip=-3.5ex plus-1ex minus -.2ex,%
+afterskip=2.5ex plus 0.2ex minus 0.2ex]{subparagraph}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\vspace*{0.5cm}\hrulefill
-\paragraph{First Workpackage.}\mbox{}\\
 \hrulefill
+\paragraph{First Workpackage.}
 \label{wp:1}
 
 \input{wp/wp1.tex}
 
-\vspace*{0.5cm}\hrulefill
-\paragraph{Second Workpackage.}\mbox{}\\
 \hrulefill
+\paragraph{Second Workpackage.}
 \label{wp:2}
 
 \input{wp/wp2.tex}
@@ -158,7 +161,13 @@ Financial support is requested for \todo[inline]{three years}.
 %% This is not directly part of the DFG TRF template, but always helpful in my eyes
 \let\theparagraph=\oldpara
 \paragraph*{Time considerations}
-\todo[inline]{put timeline here, if needed}
+\vspace{-0.5cm}
+\begin{figure}[h]
+	\centering
+  	\resizebox{\textwidth}{!}{\includestandalone[mode=tex]{gantt/gantt}}
+	\caption{Workpackage time considerations in months (M) and assigned person-months (PM) for Institute of ABC (ABC) and Institute for CDE (CDE)}
+	\label{fig:timeline}
+\end{figure}
 
 
 \section{Bibliography concerning the state of the art, the research objectives, and the work programme}

--- a/gantt/gantt.tex
+++ b/gantt/gantt.tex
@@ -1,0 +1,75 @@
+\documentclass{standalone}
+
+\usepackage{pgfgantt}
+\usepackage[binary-units = true, exponent-product = \cdot]{siunitx}
+\sisetup{detect-all}
+
+\begin{document}
+	\begin{ganttchart}[
+		canvas/.append style={fill=none, draw=black!5, line width=.75pt},
+		hgrid style/.style={draw=black!5, line width=.75pt},
+		vgrid={*1{draw=black!5, line width=.75pt}},
+		title height=1,
+		title/.style={draw=black!5, line width=.75pt},
+		include title in canvas=false,
+		title label font=\footnotesize,
+		x unit=0.7cm,
+		y unit title=0.45cm,
+		y unit chart=0.45cm,
+		bar/.append style={fill=dfgblue, draw=none},
+		bar label font=\footnotesize,
+		group/.append style={fill=dfglightblue, draw=none},
+		group label font=\bfseries\footnotesize,
+		group left shift=0,
+		group right shift=0,
+		group height=.5,
+		group peaks tip position=0
+		]{1}{12}
+		
+		\definecolor{dfgblue}{RGB}{0, 77, 162}
+		\definecolor{dfglightblue}{RGB}{104, 163, 217}
+		
+		\newcommand{\gwa}{7cm} %description
+		\newcommand{\gwb}{0.7cm} %ABC
+		\newcommand{\gwc}{0.7cm} %CDE
+		\newcommand{\gwd}{0.7cm} %EFG
+		\newcommand{\gwe}{0.7cm} %duration
+		
+		\newcommand{\gbar}[5]{\makebox[\gwa][l]{#1}\makebox[\gwb][c]{#2}\makebox[\gwc][c]{#3}\makebox[\gwd][c]{#4}\makebox[\gwe][c]{#5}}
+		%\newcommand{\gbar}[5]{\makebox[\gwa][l]{#1}.\makebox[\gwb][c]{#2}.\makebox[\gwc][c]{#3}.\makebox[\gwd][c]{#4}.\makebox[\gwe][c]{#5}.}\\ %use this to debug column width
+		\newcommand{\ggroup}[5]{\makebox[\gwa][l]{\textbf{#1}}\makebox[\gwb][c]{#2}\makebox[\gwc][c]{#3}\makebox[\gwd][c]{#4}\makebox[\gwe][c]{#5}}
+		
+		\gantttitle[
+		title label node/.append style={left =0 and 0pt,yshift=-0.5cm}, title/.style={draw=none, fill=none}
+		]{\gbar{}{ABC}{CDE}{PM}{M}}{0}
+		
+		gantttitlelist is not standalone compatible - do not use
+		\gantttitle{Year~1}{4}
+		\gantttitle{Year~2}{4}
+		\gantttitle{Year~3}{4}\\
+		\gantttitle{Q1}{1}
+		\gantttitle{Q2}{1}
+		\gantttitle{Q3}{1}
+		\gantttitle{Q4}{1}
+		\gantttitle{Q1}{1}
+		\gantttitle{Q2}{1}
+		\gantttitle{Q3}{1}
+		\gantttitle{Q4}{1}
+		\gantttitle{Q1}{1}
+		\gantttitle{Q2}{1}
+		\gantttitle{Q3}{1}
+		\gantttitle{Q4}{1}\\
+		
+		\ganttgroup{\ggroup{\ref{wp:1} First Workpackage.}{}{}{}{}}{1}{12} \\
+        \ganttgroup[group/.style={draw=none, fill=none}]{\ggroup{\hphantom{\ref{wp:1}} Second Line}{}{}{}{}}{6}{12} \\
+		\ganttbar{\gbar{Meeting Schedule}{1}{1}{2}{36}}{1}{12} \\
+		\ganttbar{\gbar{Dissemination of Results}{2}{2}{4}{24}}{5}{12} \\
+		
+		\ganttgroup{\ggroup{\ref{wp:2} Second Workpackage}{}{}{}{}}{1}{5}
+		\ganttgroup{}{10}{10} \\
+		\ganttbar{\gbar{uniqueness of the Myotis system}{4}{2}{6}{9}}{1}{3} \\
+		\ganttbar{\gbar{aspects of the Myotis system}{4}{5}{9}{12}}{3}{5}
+		\ganttbar{}{10}{10}
+		
+	\end{ganttchart}
+\end{document}

--- a/proposal.sty
+++ b/proposal.sty
@@ -19,6 +19,7 @@
 
 \usepackage{tikz}
 \usepackage{pgfplots}
+\usepackage{standalone}
 \pgfplotsset{compat=newest}
 
 \usepackage[backend = biber,

--- a/wp/wp1-german.tex
+++ b/wp/wp1-german.tex
@@ -1,6 +1,6 @@
 \lipsum[1]
 
-\subsubsection*{Investigation of unique characteristics of the \emph{Myotis} immune system}
+\subparagraph*{Investigation of unique characteristics of the \emph{Myotis} immune system}
 \lipsum[2]
 
 \bigskip

--- a/wp/wp1.tex
+++ b/wp/wp1.tex
@@ -1,6 +1,6 @@
 \lipsum[1]
 
-\subsubsection*{Investigation of unique characteristics of the \emph{Myotis} immune system}
+\subparagraph*{Investigation of unique characteristics of the \emph{Myotis} immune system}
 \lipsum[2]
 
 \bigskip

--- a/wp/wp2-german.tex
+++ b/wp/wp2-german.tex
@@ -1,6 +1,6 @@
 \lipsum[1]
 
-\subsubsection*{Investigation of unique characteristics of the \emph{Myotis} immune system}
+\subparagraph*{Investigation of unique characteristics of the \emph{Myotis} immune system}
 \lipsum[2]
 
 \bigskip

--- a/wp/wp2.tex
+++ b/wp/wp2.tex
@@ -1,6 +1,6 @@
 \lipsum[1]
 
-\subsubsection*{Investigation of unique characteristics of the \emph{Myotis} immune system}
+\subparagraph*{Investigation of unique characteristics of the \emph{Myotis} immune system}
 \lipsum[2]
 
 \bigskip


### PR DESCRIPTION
Hi,

I have added a gantt chart to the template as discussed in #1. Additionally the workpackage numbering didn't work for me so I added our solution of using subparagraph to it. Now it is also possible to activate numbering for sub-workpackages by simply using subparagraph instead of subparagraph*.