### PR TITLE
Change the page numbering so that first and second part are numbered independantly with total number per part (closes #30)

### DIFF
--- a/dfg-german.tex
+++ b/dfg-german.tex
@@ -195,7 +195,7 @@ accessible for future use.
 %\AtNextBibliography{\small}
 \printbibliography[notcategory=reviewed, notcategory=nonreviewed, notcategory=patents_pending, notcategory=patents, heading=none]
 
-\clearpage
+\backmatter
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%  SUPPLEMENT  (new since 04/2020) %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/dfg.tex
+++ b/dfg.tex
@@ -191,7 +191,7 @@ accessible for future use.
 \newrefcontext
 \printbibliography[notcategory=reviewed, notcategory=nonreviewed, notcategory=patents_pending, notcategory=patents, heading=none, env=bibliographyNUM]	
 
-\clearpage
+\backmatter
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%  SUPPLEMENT  (new since 04/2020) %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/proposal.sty
+++ b/proposal.sty
@@ -9,7 +9,8 @@
 \usepackage[exponent-product = \cdot]{siunitx}
 \usepackage{rotating}
 \usepackage{helvet}
-\usepackage{lastpage}
+\usepackage[pagecontinue=false]{pageslts}
+\pagenumbering{arabic}
 \usepackage{scrlayer-scrpage}
 \usepackage{eurosym}
 \usepackage{fp}
@@ -83,17 +84,20 @@
 \hyphenpenalty 3000
 \doublehyphendemerits 50000000
 
+
 \newcommand{\total}{}
+
+\newcommand{\pagenumtype}{arabic}
 \DeclareOption{german}{
     \sisetup{locale=DE}
     \AtBeginDocument{\selectlanguage{ngerman}}
-    \renewcommand{\pagemark}{Seite \thepage~von \pageref{LastPage}}
+    \renewcommand{\pagemark}{Seite \thepage~von \lastpageref{pagesLTS.\pagenumtype}}
     \renewcommand{\total}{Summe}
 }
 \DeclareOption{english}{
     \sisetup{locale=US}
     \AtBeginDocument{\selectlanguage{english}}
-	\renewcommand{\pagemark}{page \thepage~of \pageref{LastPage}}
+	\renewcommand{\pagemark}{page \thepage~of \lastpageref{pagesLTS.\pagenumtype}}
     \renewcommand{\total}{Total}
 }
 \ExecuteOptions{german}
@@ -101,6 +105,13 @@
 \ohead*{\pagemark}
 \cfoot*{}
 \chead{}
+
+\newcommand{\backmatter}{
+    \clearpage
+    \pagenumbering{Roman}
+    \renewcommand{\pagenumtype}{Roman}
+}
+
 
 \KOMAoptions{paper=a4}
 \KOMAoption{fontsize}{11pt}


### PR DESCRIPTION
First part is numbered with the total number up to section 3
Second part is numbered independantly with roman numbers(to distinguish) showing the total number only of section 4-5
This closes #30