### PR TITLE
update minor differences to original template

### DIFF
--- a/dfg-german.tex
+++ b/dfg-german.tex
@@ -213,8 +213,7 @@ accessible for future use.
 \subsubsection{Allgemeine ethische Aspekte}
 \todo[inline]{Text}
 
-\subsubsection{Erläuterungen zu den vorgesehenen Untersuchungen bei Versuchen an 
-Menschen oder an vom Menschen entnommenem Material}
+\subsubsection{Erläuterungen zu den vorgesehenen Untersuchungen am Menschen, an vom Menschen entnommenem Material oder mit identifizierbaren Daten}
 \todo[inline]{Text}
 
 \subsubsection{Erläuterungen zu den vorgesehenen Untersuchungen bei Versuchen an Tieren}
@@ -325,7 +324,7 @@ The following staff positions are requested for \todo[inline]{xx} years each:
 We apply for a total of 10\,000\,\euro\ for travel expenses.
 \position{Travel}{10000}
 
-\subsubsubsection{Mittel für wissenschaftliche Gäste \textnormal{(ausgenommen Mercator Fellows)}}
+\subsubsubsection{Mittel für wissenschaftliche Gäste \textnormal{(ausgenommen Mercator-Fellow)}}
 None.
 
 \subsubsubsection{Mittel für Versuchstiere}


### PR DESCRIPTION
Found some minor differences in the template compared to the original: 
https://www.dfg.de/formulare/53_01_elan/53_01_de_elan.rtf

Another thing to discuss here:
Does is make sense to add the template version `DFG-Vordruck 53.01 - 03/22` to the latex-edition in the header?
This is not present at the moment. But may useful? What do you think?
![image](https://user-images.githubusercontent.com/62549000/186090134-ade88f27-f06a-467a-8f96-8cb2bb6b014e.png)
