### PR TITLE
Use ngerman option in documentclass options so all packages pick it up

### DIFF
--- a/dfg-german.tex
+++ b/dfg-german.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass[ngerman]{scrartcl}
 
 %This template is based on the DFG rtf form (see Readme on GitHub for last accessed date, and version in the header of the compiled PDF)
 %


### PR DESCRIPTION
Some packages like cleveref require that the documentclass has the ngerman option to handle german texts properly.