### PR TITLE
adjust page margins

### DIFF
--- a/dfg.tex
+++ b/dfg.tex
@@ -9,7 +9,7 @@
 \usepackage[english]{proposal}
 
 % final version?
-\setboolean{finalcompile}{false}
+\setboolean{finalcompile}{true}
 
 % show DFG template version the current LaTeX template is based on in the header. Will be deactivated when 'finalcompile' is set 'true'
 \ifthenelse{\boolean{finalcompile}}{}{\ihead*{DFG-form 53.01 - 03/24}}

--- a/proposal.sty
+++ b/proposal.sty
@@ -6,7 +6,9 @@
 %\usepackage[hidelinks]{hyperref}
 \usepackage{microtype}
 \usepackage{csquotes}
-\usepackage[headheight = 28pt, tmargin = 70pt, lmargin = 55pt, rmargin = 55pt, bmargin = 70pt]{geometry}
+%\usepackage[headheight = 28pt, tmargin = 70pt, lmargin = 55pt, rmargin = 55pt, bmargin = 70pt]{geometry}
+% use DFG margins according to https://github.com/hoelzer/dfg/issues/56
+\usepackage[headheight = 1cm, tmargin = 2.5cm, lmargin = 2.5cm, rmargin = 2cm, bmargin = 1.5cm]{geometry}
 \usepackage[exponent-product = \cdot]{siunitx}
 \usepackage{rotating}
 \usepackage{helvet}


### PR DESCRIPTION
Changed the page margins in the style file to using cm and put the ones required by the DFG template. However, when printing this out, it might still result in different page margins based on the printer setup. I changed my printing setup to fill the entire page and use 100% scaling (the default was 97%). Still, its not precisely the numbers written in the style file

```bash
\usepackage[headheight = 1cm, tmargin = 2.5cm, lmargin = 2.5cm, rmargin = 2cm, bmargin = 1.5cm]{geometry}
```

related to #56 