### PR TITLE
Add missing % to comment

### DIFF
--- a/gantt/gantt.tex
+++ b/gantt/gantt.tex
@@ -43,7 +43,7 @@
 		title label node/.append style={left =0 and 0pt,yshift=-0.5cm}, title/.style={draw=none, fill=none}
 		]{\gbar{}{ABC}{CDE}{PM}{M}}{0}
 		
-		gantttitlelist is not standalone compatible - do not use
+		% gantttitlelist is not standalone compatible - do not use
 		\gantttitle{Year~1}{4}
 		\gantttitle{Year~2}{4}
 		\gantttitle{Year~3}{4}\\


### PR DESCRIPTION
Missing % in comment line. It seems to compile anyway, but occasionally I got a bunch of warnings because of this line,