### PR TITLE
Increase maxbibnames from 10 to 99

### DIFF
--- a/proposal.sty
+++ b/proposal.sty
@@ -38,7 +38,7 @@
 	defernumbers=true,
 	labelnumber,
     hyperref = true,
-    maxbibnames = 10,
+    maxbibnames = 99,
     sorting=none,%remove this to have things sorted, e.g. use style=alphabetic
     ]{biblatex}
 \renewcommand*{\labelalphaothers}{}


### PR DESCRIPTION
In our last two submissions, we received feedback requesting that the full names of all authors be included when listing publications. Providing complete author names is important for the review process to ensure proper attribution and transparency. Therefore, the use of the abbreviation “et al.” is no longer sufficient.
To address this, I have increased the default display limit of author names to 99, ensuring all authors are fully listed by default.