### PR TITLE
* fix warning about deprecated option

### DIFF
--- a/proposal.sty
+++ b/proposal.sty
@@ -29,7 +29,7 @@
 
 \RequirePackage[backend=biber,
   style = numeric, %alphabetic, numeric
-  firstinits = true,
+  giveninits = true,
   natbib = true,
 	url=false,
 	doi=true,


### PR DESCRIPTION
Firstinits is an deprecated options and should be replaced by giveninits. This PR fixes it.