### PR TITLE
* fix colors of cite keys: make cite keys of non-important publicatio…

### DIFF
--- a/proposal.sty
+++ b/proposal.sty
@@ -95,7 +95,7 @@
 \AtEveryCitekey{%
   \ifcategory{important}%
     {\hypersetup{citecolor=impentry}\bfseries\color{impentry}}%
-    {}%
+    {\hypersetup{citecolor=impentry}\color{impentry}}%
   }
 
 % To also colorize the labels in the bibliography:


### PR DESCRIPTION
Cite keys of non-important publications appeared midnight blue while those of important ones are black. This PR fixes it (PR redone).