### PR TITLE
docs: add online compilation option via SpicyChai LaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ conda create -n biber -c malramsay biber
 conda activate biber
 ```
 
+### Online (no installation needed)
+If you don't want to install LaTeX locally, you can edit and compile this template entirely in the browser using [SpicyChai LaTeX](https://latex.spicychai.com/). It's a free online LaTeX editor with:
+
+- Real-time PDF preview as you type
+- AI-powered template population — useful for quickly filling in structured sections like work packages, funding tables, and Gantt chart data
+- Pre-built templates for grant proposals and academic documents
+- No account required for basic use (500 free credits on signup, 1 credit per rendered page)
+
+Simply upload your `.tex`, `.sty`, and `.bib` files and compile directly in the browser.
+
 ### Docker
 You can also use a Docker container that comes with all dependencies (pdflatex, biber, ...) to compile the template. Thus, no installation of LaTeX, Biber, etc... is needed on your local system.
 


### PR DESCRIPTION
## Summary
- Adds an "Online (no installation needed)" section under Compilation, alongside the existing Biber and Docker sections
- [SpicyChai LaTeX](https://latex.spicychai.com/) provides browser-based LaTeX compilation with AI-powered template population and real-time PDF preview
- Particularly useful for researchers who want to quickly start editing DFG proposals without setting up a local LaTeX environment
- Free to use: 500 credits on signup (1 credit per rendered page), no account required for basic use

## Disclosure
I am affiliated with SpicyChai LaTeX. This PR is submitted in good faith to provide users of this template with an additional free online compilation option, similar to the Docker alternative already documented.